### PR TITLE
Add option to set different compiler prefix, add build documentation.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,12 @@
 all: build
 
 BUILD ?= "build"
+CMAKE_FLAGS ?= "-DPREFIX=riscv64-elf-"
 
 .PHONY: build
 build:
 	mkdir -p ${BUILD}
-	cd ${BUILD}; cmake ../src
+	cd ${BUILD}; cmake ${CMAKE_FLAGS} ../src
 	cd ${BUILD}; make
 
 .PHONY: clean

--- a/README.md
+++ b/README.md
@@ -23,6 +23,51 @@ Currently supported values:
 | 1     | WHY2025 prototype 1 |
 | 2     | WHY2025 prototype 2 |
 
+## Build instructions
+
+### Setup the tool chain
+
+TODO: Write setup toolchain here.
+
+### Building the .bin file
+
+The build configuration is configured to use the compiler prefix 'riscv64-elf-'. 
+(for exammple: riscv64-elf-gcc, riscv64-elf-g++)
+
+When your system has a toolchain with this prefix, you can just use:
+
+```bash
+make
+```
+
+When your compiler has another prefix, for example 'riscv32-unknown-elf-' use the following:
+
+```bash
+make CMAKE_FLAGS="-DPREFIX=custom-prefix-" build
+```
+
+For example on my system, the compiler prefix is 'riscv32-unknown-elf-':
+
+```bash
+make CMAKE_FLAGS="-DPREFIX=riscv32-unknown-elf" build
+```
+
+## Deploying to the badge
+
+After the build has run successfully, a file named 'main.bin' is placed in the project root.
+
+The 'main.bin' file needs to be copied into the why2025-firmware-esp32p4 project.
+
+```bash
+cp ./main.bin < path to why2025-firmware-esp32p4 >/main/ch32_firmware.bin'
+```
+
+After this, build the P4 firmware again, and flash it to the badge.
+
+When the badge reboots after the flash it'll flash the CH32 firmware as part of the boot sequence.
+
+(In case instructions are needed to compile the P4 firmware, the README.md of the P4 firmware might help)
+
 ## License
 
 This firmware, copyright 2024 Nicolai Electronics, is made available under the terms of the MIT license, see [LICENSE](LICENSE) for the full license text. The platform files come from the [ch32v003fun](https://github.com/cnlohr/ch32v003fun) project by Cnlohr and are also licensed under the terms of the MIT license. Please see the [CH32V003 LICENSE](src/platform/LICENSE) for a list of copyright holders.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.21.0)
 cmake_policy(VERSION 3.21)
 
 set(PROJECT_NAME "coprocessor")
-set(PREFIX "riscv64-elf-")
+set(PREFIX "riscv64-elf-" CACHE STRING "Toolchain prefix")
 
 project(${PROJECT_NAME} LANGUAGES C)
 


### PR DESCRIPTION
I add this feature to the build process to make sure tool chains that have a different compiler name prefix can also be used without the need to change the CMakeLists.txt.

Also added a bit of documentation on how to use the feature and how to deploy the resulting .bin file.